### PR TITLE
Update and rename critical.js to inject-nonces.js

### DIFF
--- a/critical-css-deprecated.js
+++ b/critical-css-deprecated.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+console.warn(`*****
+Warning: this tool does not generate Critical CSS anymore.
+Please consider using a different script to generate Critical CSS before running this script.
+*****`);
+
+require('child_process').fork('./inject-nonces.js');

--- a/inject-nonces.js
+++ b/inject-nonces.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const { program } = require("commander")
-const critical = require("critical")
 const glob = require("glob")
 const cheerio = require("cheerio")
 const fs = require("fs")
@@ -27,15 +26,7 @@ glob("**/*.html", async (er, files) => {
 
   files.map(async (file) => {
     try {
-      const html = await critical.generate({
-        base: ".",
-        src: file,
-        width: 1300,
-        height: 900,
-        inline: true,
-        minify: true,
-      })
-
+      const html = fs.readFileSync(file)
       const $ = cheerio.load(html)
 
       $("head style").after(`<script nonce="${nonce}">window.__webpack_nonce__ = '${nonce}'</script>`);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Injects nonces and subresource integrity checks.",
   "bin": {
     "inject-security-attrs": "./inject-nonces.js",
-    "critical-css-csp": "./inject-nonces.js"
+    "critical-css-csp": "./critical-css-deprecated.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "pre-website-deploy",
-  "version": "0.1.0",
-  "description": "Injects critical CSS, nonces and Subresource integrity checks.",
+  "version": "0.2.0",
+  "description": "Injects nonces and subresource integrity checks.",
   "bin": {
-    "critical-css-csp": "./critical.js"
+    "inject-security-attrs": "./inject-nonces.js",
+    "critical-css-csp": "./inject-nonces.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -21,7 +22,6 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "commander": "^5.1.0",
-    "critical": "^1.3.9",
     "glob": "^7.1.6"
   }
 }


### PR DESCRIPTION
Remove critical CSS. No need to pursue this approach since we're not using bootstrap gigantic framework anymore.